### PR TITLE
fix(user): 로그인 세션 만료 시 로그인 페이지로 라우팅

### DIFF
--- a/frontend/armageddon/src/api/client.js
+++ b/frontend/armageddon/src/api/client.js
@@ -59,17 +59,23 @@ export const apiRequest = async (endpoint, options = {}) => {
     })
 
   // 401 에러 시 토큰 갱신 시도
-  if (response.status === 401 && tokens?.refreshToken && !options.isRetry) {
-    try {
-      const refreshed = await refreshAccessToken(tokens.refreshToken)
-      if (refreshed) {
-        // 토큰 갱신 성공, 원래 요청 재시도
-        return apiRequest(endpoint, { ...options, isRetry: true })
+  if (response.status === 401) {
+    // refreshToken이 있고 아직 재시도하지 않은 경우 갱신 시도
+    if (tokens?.refreshToken && !options.isRetry) {
+      try {
+        const refreshed = await refreshAccessToken(tokens.refreshToken)
+        if (refreshed) {
+          // 토큰 갱신 성공, 원래 요청 재시도
+          return apiRequest(endpoint, { ...options, isRetry: true })
+        }
+      } catch {
+        // 갱신 중 예외 발생 - 아래에서 처리
       }
-    } catch {
-      clearTokens()
-      window.location.href = '/login'
     }
+    // refreshToken이 없거나 갱신 실패한 경우 로그인 페이지로 리다이렉트
+    clearTokens()
+    window.location.href = '/login'
+    throw new Error('인증이 만료되었습니다. 다시 로그인해주세요.')
   }
 
   const data = await response.json()


### PR DESCRIPTION
## 변경 사항
- 로그인 세션 만료 시 로그인 페이지로 돌아가도록 수정했습니다.

## 작업 내용
- [ ] 기능 구현
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 디자인 요소 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)

## 체크리스트
- [x] Push 전 pull dev 했는가
- [x] 불필요한 코드/주석이 없는가

## 참고 사항(생략 가능)
- 세션 시간을 늘리고 싶은 분들은 **application-local.yml** 의 **expiration**을 늘려주세요. 디코 기준 30분으로 되어 있습니다.
